### PR TITLE
Map digits

### DIFF
--- a/checkDig.c
+++ b/checkDig.c
@@ -1,0 +1,28 @@
+#include "main.h"
+
+void bomb_setn(block_t bomb) 
+{   
+    pixel_move_pos(bomb, DIR_RIGHT);
+
+    for(uint8 i = 0; i < 4; i++)
+    {
+        pixel_move_pos(bomb, i);
+        bomb->value++;
+
+        if (i == 3)
+        {
+            pixel_move_pos(bomb, DIR_UP);
+            bomb->value++;
+        }
+
+        else 
+        {
+        pixel_move_pos(bomb, i+1);
+        bomb->value++;
+        }
+    }        
+}
+//logic*
+//  [→][→][↓]
+//  [↑][↑][↓]
+//  [↑][←][←]

--- a/main.c
+++ b/main.c
@@ -1,19 +1,20 @@
 #include "main.h"
 
-void main(void){
+void main(void)
+{
     srand(time(NULL));
 
-    block_t bomb;
+    block_t selector; //Current "cursor" position
 
-    for(i = 0; i<8;i++){
-        generate_random_coords(void);
-        row = bomb.row;
-        col = bomb.column;
-        face = bomb.face;
-
-        mapvalue[face][row][col];
-
+    //Bombs are mapped and saved.
+    for(int i = 0; i < 8;i++)
+    {
+        bombLocations[i] = generate_random_coords(-1); //C: Doesn't prevent 2 bombs being placed in the same location
+        mapvalue[bombLocations[i].face][bombLocations[i].row][bombLocations[i].column] = bombLocations[i].val;
     }
 
-
+    for (int i = 0; i < sizeof(bombLocations); i++)
+    {
+        void bomb_setn(bombLocations[i]);
+    }
 }

--- a/main.h
+++ b/main.h
@@ -15,7 +15,7 @@
 
 typedef enum
 {
-  TYPE_SELECT = 0xFFFFFF, // White
+  TYPE_SELECT, // White
   TYPE_BOMB = 0xFE0000,   // Red
   TYPE_ONE = 0x4363D8,    // Blue
   TYPE_TWO = 0x3CB44B,    // Green
@@ -26,6 +26,12 @@ typedef enum
   TYPE_SEVEN = 0x5F530F,  // Purple
   TYPE_EIGHT = 0x5F530F   // Brown
 } ItemType;
+
+const uint8_t [10][3] = { //GRB
+  {255,255,255},
+  { , , },
+  { , , }
+}
 
 typedef enum
 {

--- a/main.h
+++ b/main.h
@@ -4,18 +4,46 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <stdlib.h>
 #include <util/twi.h>
 #include <avr/interrupt.h>
 #include <iostream>
-#include <stdlib.h>
 #include <time.h> 
 
-typedef struct block{
+#define ERROR_COLOR 0x000000
+#define ITEM_TYPE_COUNT 10
+
+typedef enum
+{
+  TYPE_SELECT = 0xFFFFFF, // White
+  TYPE_BOMB = 0xFE0000,   // Red
+  TYPE_ONE = 0x4363D8,    // Blue
+  TYPE_TWO = 0x3CB44B,    // Green
+  TYPE_THREE = 0xFFCA00,  // Yellow
+  TYPE_FOUR = 0xF032E6,   // Pink
+  TYPE_FIVE = 0xF58231,   // Orange
+  TYPE_SIX = 0x46F0F0,    // Cyan
+  TYPE_SEVEN = 0x5F530F,  // Purple
+  TYPE_EIGHT = 0x5F530F   // Brown
+} ItemType;
+
+typedef enum
+{
+  DIR_UP = 0,
+  DIR_LEFT = 1,
+  DIR_DOWN = 2,
+  DIR_RIGHT = 3
+} Direction;
+
+typedef struct block
+{
     uint8_t row;
     uint8_t column;
     uint8_t face;
     uint8_t value;
 }block_t;
+
+block_t bombLocations[7];
 
 block_t mapRGB[5][3][3][3];     
 block_t mapvalue[5][3][3];
@@ -27,3 +55,4 @@ uint8_t face;
 void generate_random_coords(void);
 bool pixel_move_pos(uint8_t row, uint8_t *const column, uint8_t *const face, uint8_t *const direction);
 void dir_check(uint8_t direction, uint8_t up_block, uint8_t left_block, uint8_t right_block, uint8_t down_block);
+void bomb_setn(block_t bomb); 

--- a/mapping.c
+++ b/mapping.c
@@ -1,6 +1,7 @@
 #include "main.h"
 
-void generate_random_coords(void) {
+block_t generate_random_coords(uint8_t val) 
+{
 
     block_t b;
 
@@ -8,5 +9,7 @@ void generate_random_coords(void) {
     b.row = rand() % 3;
     b.column = rand() % 3;
 
-    b.value = 10;
+    b.value = val;
+
+    return b;
 }

--- a/move.c
+++ b/move.c
@@ -1,49 +1,81 @@
 #include "main.h"
 
-void dir_check(uint8_t direction, uint8_t up_block, uint8_t left_block, uint8_t right_block, uint8_t down_block) {
-    if (direction == LEFT) {
-        *column = 3;
-        *face = left_block;
+void dir_check(block_t *pos, uint8_t direction, uint8_t up_block, uint8_t left_block, uint8_t right_block, uint8_t down_block) 
+{
+    if (direction == LEFT) 
+    {
+        pos->column = 3;
+        pos->face = left_block;
     }
-    else if (direction == UP) {
-        *row = 3;
-        *face = up_block;
+
+    else if (direction == UP) 
+    {
+        pos->row = 3;
+        pos->face = up_block;
     }
-    else if (direction == RIGHT) {
-        *column = 1;
-        *face = right_block;
+
+    else if (direction == RIGHT) 
+    {
+        pos->column = 1;
+        pos->face = right_block;
     }
-    else {
-        *row = 1;
-        *face = down_block;
+
+    else 
+    {
+        pos->row = 1;
+        pos->face = down_block;
     }
 
 }
 
-bool pixel_move_pos(uint8_t row, uint8_t *const column, uint8_t *const face, uint8_t *const direction)
-{
-    switch (*face) { // Dereference the pointer to get the integer value
-        case 1:
-            dir_check(direction, 5, 2, 4);
-            return true;
-
-        case 2:
-            dir_check(direction, 5, 3, 1);
-            return true;
-
-        case 3:
-            dir_check(direction, 5, 4, 2);
-            return true;
-
-        case 4:
-            dir_check(direction, 5, 1, 3);
-            return true;
-
-        case 5:
-            dir_check(direction, 2, 1, 3, 4);
-            return true;
-
-        default:
-            return false;
+bool pixel_move_pos(block_t *pos, uint8_t direction)
+{   
+    if (direction == DIR_UP) && (pos->row != 0) 
+    {
+        pos->row = (pos->row)++;
     }
+
+    else if (direction == DIR_DOWN) && (pos->row != 2) 
+    {
+        pos->row = (pos->row)--;
+    }
+
+    else if (direction == DIR_LEFT) && (pos->column != 0) 
+    {
+        pos->column = (pos->column)--;
+    }
+
+    else if (direction == DIR_RIGHT) && (pos->column != 2) 
+    {
+        pos->column = (pos->column)++;
+    }
+
+    else
+    {
+        switch (pos->face) 
+        {
+            case 1: 
+                dir_check(pos, *direction, 5, 2, 4, 0); 
+                return true;
+
+            case 2: 
+                dir_check(pos, *direction, 5, 3, 1, 0); 
+                return true;
+
+            case 3: 
+                dir_check(pos, *direction, 5, 4, 2, 0); 
+                return true;
+
+            case 4: 
+                dir_check(pos, *direction, 5, 1, 3, 0); 
+                return true;
+
+            case 5: 
+                dir_check(pos, *direction, 2, 1, 3, 4); 
+                return true;
+
+            default: 
+                return false;
+                
+        }
 }


### PR DESCRIPTION
A new feature checkDig was create so we can set all the surrounding values of a bomb to increase by one. When the surround 3x3 area is overlapped by 2 or more bombs the number will increase to display how many bombs are near that block. Bugs were also fixed in this branch such as making the pixel_move_pos to also move when it's not out of index. Previously the function only moved the selector when it was on a edge. A block_t array was also made to keep track of all the bomb locations. In summary some minor bugs were fixed, a additional feature checkDig was created. Now the main.c file should map all the value on the mapvalue.